### PR TITLE
Add spark master port configuration option

### DIFF
--- a/start-spark
+++ b/start-spark
@@ -5,6 +5,11 @@ if [[ -z "${HDFS_USER}" ]]; then
   export HDFS_USER=spark
 fi
 
+# Set default Spark Master communication port
+if [[ -z "${SPARK_MASTER_PORT_USER}" ]]; then
+  export SPARK_MASTER_PORT_USER=7077
+fi
+
 if [[ "${1}" = 'master' ]]; then
   # Start Hadoop NameNode
   start-hadoop namenode daemon
@@ -14,11 +19,11 @@ elif [[ "${1}" = 'worker' ]]; then
   # Start Hadoop DataNode
   start-hadoop datanode $2 daemon
   # Wait for the master to start
-  while ! nc -z $2 7077; do
+  while ! nc -z $2 ${SPARK_MASTER_PORT_USER}; do
     sleep 2;
   done;
   # Start Spark Worker
-  spark-class org.apache.spark.deploy.worker.Worker spark://$2:7077
+  spark-class org.apache.spark.deploy.worker.Worker spark://$2:${SPARK_MASTER_PORT_USER}
 else
   echo "Invalid command '${1}'" >&2
   exit 1


### PR DESCRIPTION
Add Spark master communication port configuration in startup script. Use `SPARK_MASTER_PORT_USER` to override, default: `7077`.